### PR TITLE
hook_article_button(): simplify path retrieval

### DIFF
--- a/yourls/init.php
+++ b/yourls/init.php
@@ -40,7 +40,7 @@ class Yourls extends Plugin {
 	function hook_article_button($line) {
 		$article_id = $line["id"];
 
-		$rv = "<img src=\"".basename(dirname(dirname(__FILE__)))."/yourls/yourls.png\"
+		$rv = "<img src=\"plugins/yourls/yourls.png\"
 			class='tagsPic' style=\"cursor : pointer\"
 			onclick=\"shareArticleToYourls($article_id)\"
 			title='".__('Send article to Yourls')."'>";


### PR DESCRIPTION
We don't need to operate with the basename() function, since we *know* how the path is made up. Just write the targeted path in there. :)