### PR TITLE
update js to ttrss v18.12 (fca78f7) and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tt-rss-yourls
 =============
 
-This plugin is known to be working with the lastest stable version of ttrss 1.7.9.
+This plugin is known to be working with the lastest stable version of ttrss v18.12 (fca78f7).
 for changes please use the 'dev' branch 
 
 A plugin for Tiny Tiny RSS, to shorten urls via Yourls
@@ -15,7 +15,7 @@ Requierement
 
 Installation
 ------------
-* Copy the *yourls* folder to your tt-rss *plugins/* folder.
+* Copy the *yourls* folder to your tt-rss *plugins.local/* folder.
 * Go to your tt-rss Preference page
 * Under *Plugins* section enable yourls plugin
 * A new pref pane will show up, named ... *Yourls* ;)
@@ -26,7 +26,7 @@ Installation
 
 Usage
 ------
-While on an article, you will see a Y shaped Yourls icon. Clicking on it will bring up a dialog with the shortened URL of the article link. Within the dialog icons to chare this shortened link via Facebook and/or Twitter will also be displayed.
+While on an article, either clicking on the "Y" shaped Yourls icon or using the keyboard shortcut `s+y` will bring up a dialog with the shortened URL of the article link. Within the dialog icons to chare this shortened link via Facebook and/or Twitter will also be displayed.  
 
 ENJOY ! ;)
 

--- a/yourls/README.txt
+++ b/yourls/README.txt
@@ -1,6 +1,0 @@
-
--Activate plugin in Plugins Prefs
--Then click on the Yourls Plugins pane
--Type  your yourls base url (form : http://sho.rt) and you API key
--Click save ...
--ENJOY !

--- a/yourls/init.php
+++ b/yourls/init.php
@@ -6,20 +6,33 @@ class Yourls extends Plugin {
 	function init($host) {
 		$this->host = $host;
 		$this->curl_yourls = $curl_yourls;
-                $this->curl_yourls = curl_init() ;
-                curl_setopt($this->curl_yourls, CURLOPT_RETURNTRANSFER, true);
-                curl_setopt($this->curl_yourls, CURLOPT_FOLLOWLOCATION, true);
-
-
+        $this->curl_yourls = curl_init() ;
+        	curl_setopt($this->curl_yourls, CURLOPT_RETURNTRANSFER, true);
+        	curl_setopt($this->curl_yourls, CURLOPT_FOLLOWLOCATION, true);
 		$host->add_hook($host::HOOK_ARTICLE_BUTTON, $this);
 		$host->add_hook($host::HOOK_PREFS_TAB, $this);
+		$host->add_hook($host::HOOK_HOTKEY_MAP, $this);
+		$host->add_hook($host::HOOK_HOTKEY_INFO, $this);
 	}
 
 	function about() {
-		return array(1.0,
+		return array("1.1.0",
 				"Shorten article Link using Yourls",
 				"Beun and acaranta");
 	}
+
+	function hook_hotkey_map($hotkeys) {
+	$hotkeys['s y'] = 'send_to_yourls';
+
+		return $hotkeys;
+	}
+
+	function hook_hotkey_info($hotkeys) {
+		$hotkeys[__("Article")]["send_to_yourls"] = __("Shorten article link with YOURLS");
+
+		return $hotkeys;
+	}
+
 	function save() {
 		$yourls_url = db_escape_string($_POST["yourls_url"]);
 		$this->host->set($this, "Yourls_URL", $yourls_url);
@@ -29,9 +42,9 @@ class Yourls extends Plugin {
 		echo "Value Yourls API set to $yourls_api";
 	}
 
-        function api_version() {
-                return 2;
-        }
+    function api_version() {
+            return 2;
+    }
 
 	function get_js() {
 		return file_get_contents(dirname(__FILE__) . "/yourls.js");
@@ -40,7 +53,7 @@ class Yourls extends Plugin {
 	function hook_article_button($line) {
 		$article_id = $line["id"];
 
-		$rv = "<img src=\"".basename(dirname(dirname(__FILE__)))."/yourls/yourls.png\"
+		$rv = "<img id=\"yourlsImgId\" src=\"plugins.local/yourls/yourls.png\"
 			class='tagsPic' style=\"cursor : pointer\"
 			onclick=\"shareArticleToYourls($article_id)\"
 			title='".__('Send article to Yourls')."'>";
@@ -56,68 +69,59 @@ class Yourls extends Plugin {
 				WHERE id = '$id' AND ref_id = id AND owner_uid = " .$_SESSION['uid']);
 
 		if (db_num_rows($result) != 0) {
-			$title = truncate_string(strip_tags(db_fetch_result($result, 0, 'title')),
-					100, '...');
+			$title = truncate_string(strip_tags(db_fetch_result($result, 0, 'title')),100, '...');
 			$article_link = db_fetch_result($result, 0, 'link');
 		}
 
 		$yourls_url = $this->host->get($this, "Yourls_URL");
 		$yourls_api = $this->host->get($this, "Yourls_API");
+
 		curl_setopt($this->curl_yourls, CURLOPT_URL, "$yourls_url/yourls-api.php?signature=$yourls_api&action=shorturl&format=simple&url=".urlencode($article_link)."&title=".urlencode($title)) ;
 		curl_setopt($this->curl_yourls, CURLOPT_RETURNTRANSFER, true);
 		if (!ini_get('safe_mode') && !ini_get('open_basedir')) {
 			curl_setopt($this->curl_yourls, CURLOPT_FOLLOWLOCATION, true);
 		}
 		$short_url = curl_exec($this->curl_yourls) ;
+
 		curl_setopt($this->curl_yourls, CURLOPT_URL, "$yourls_url/yourls-api.php?signature=$yourls_api&action=shorturl&format=simple&url=".urlencode($article_link)."&title=".urlencode($title)) ;
 		$short_url = curl_exec($this->curl_yourls) ;
 
-		print json_encode(array("title" => $title, "link" => $article_link,
-					"id" => $id, "yourlsurl" => $yourls_url, "yourlsapi" => $yourls_api, "shorturl" => $short_url));		
+		print json_encode(array("title" => $title, "link" => $article_link, "id" => $id, "yourlsurl" => $yourls_url, "yourlsapi" => $yourls_api, "shorturl" => $short_url));		
 	}
 
 	function hook_prefs_tab($args) {
 		if ($args != "prefPrefs") return;
 
-		print "<div dojoType=\"dijit.layout.AccordionPane\" title=\"".__("Yourls")."\">";
-
+		print "<div dojoType=\"dijit.layout.AccordionPane\" 
+					title=\" <i class='material-icons'>link</i> ".__("Yourls")."\">";
 		print "<br/>";
-
 		$yourls_url = $this->host->get($this, "Yourls_URL");
 		$yourls_api = $this->host->get($this, "Yourls_API");
 		print "<form dojoType=\"dijit.form.Form\">";
-
 		print "<script type=\"dojo/method\" event=\"onSubmit\" args=\"evt\">
-			evt.preventDefault();
-		if (this.validate()) {
-			console.log(dojo.objectToQuery(this.getValues()));
-			new Ajax.Request('backend.php', {
-parameters: dojo.objectToQuery(this.getValues()),
-onComplete: function(transport) {
-notify_info(transport.responseText);
-}
-});
-}
-</script>";
-
-print "<input dojoType=\"dijit.form.TextBox\" style=\"display : none\" name=\"op\" value=\"pluginhandler\">";
-print "<input dojoType=\"dijit.form.TextBox\" style=\"display : none\" name=\"method\" value=\"save\">";
-print "<input dojoType=\"dijit.form.TextBox\" style=\"display : none\" name=\"plugin\" value=\"yourls\">";
-print "<table width=\"100%\" class=\"prefPrefsList\">";
-print "<tr><td width=\"40%\">".__("Yourls base URL")."</td>";
-print "<td class=\"prefValue\"><input dojoType=\"dijit.form.ValidationTextBox\" required=\"1\" name=\"yourls_url\" regExp='^(http|https)://.*' value=\"$yourls_url\"></td></tr>";
-	print "<tr><td width=\"40%\">".__("Yourls API Key")."</td>";
-	print "<td class=\"prefValue\"><input dojoType=\"dijit.form.ValidationTextBox\" required=\"1\" name=\"yourls_api\" value=\"$yourls_api\"></td></tr>";
-	print "</table>";
-	print "<p><button dojoType=\"dijit.form.Button\" type=\"submit\">".__("Save")."</button>";
-
-	print "</form>";
-
-	print "</div>"; #pane
-
+					evt.preventDefault();
+					if (this.validate()) {
+						console.log(dojo.objectToQuery(this.getValues()));
+						new Ajax.Request('backend.php', {
+						parameters: dojo.objectToQuery(this.getValues()),
+						onComplete: function(transport) {
+						notify_info(transport.responseText);
+						}
+						});
+					}
+				</script>";
+		print "<input dojoType=\"dijit.form.TextBox\" style=\"display : none\" name=\"op\" value=\"pluginhandler\">";
+		print "<input dojoType=\"dijit.form.TextBox\" style=\"display : none\" name=\"method\" value=\"save\">";
+		print "<input dojoType=\"dijit.form.TextBox\" style=\"display : none\" name=\"plugin\" value=\"yourls\">";
+		print "<table width=\"100%\" class=\"prefPrefsList\">";
+		print "<tr><td width=\"40%\">".__("Yourls base URL")."</td>";
+		print "<td class=\"prefValue\"><input dojoType=\"dijit.form.ValidationTextBox\" required=\"1\" name=\"yourls_url\" regExp='^(http|https)://.*' value=\"$yourls_url\"></td></tr>";
+		print "<tr><td width=\"40%\">".__("Yourls API Key")."</td>";
+		print "<td class=\"prefValue\"><input dojoType=\"dijit.form.ValidationTextBox\" required=\"1\" name=\"yourls_api\" value=\"$yourls_api\"></td></tr>";
+		print "</table>";
+		print "<p><button dojoType=\"dijit.form.Button\" type=\"submit\">".__("Save")."</button>";
+		print "</form>";
+		print "</div>"; #pane
 	}
-
 }
-
-
 ?>

--- a/yourls/init.php
+++ b/yourls/init.php
@@ -16,7 +16,7 @@ class Yourls extends Plugin {
 	}
 
 	function about() {
-		return array("1.1.0",
+		return array("1.1.1",
 				"Shorten article Link using Yourls",
 				"Beun and acaranta");
 	}
@@ -62,15 +62,14 @@ class Yourls extends Plugin {
 	}
 
 	function getInfo() {
-		$id = db_escape_string($_REQUEST['id']);
-
-		$result = db_query("SELECT title, link
-				FROM ttrss_entries, ttrss_user_entries
-				WHERE id = '$id' AND ref_id = id AND owner_uid = " .$_SESSION['uid']);
-
-		if (db_num_rows($result) != 0) {
-			$title = truncate_string(strip_tags(db_fetch_result($result, 0, 'title')),100, '...');
-			$article_link = db_fetch_result($result, 0, 'link');
+		$id = $_REQUEST['id'];
+		$sth = $this->pdo->prepare("SELECT title, link 
+									FROM ttrss_entries, ttrss_user_entries 
+									WHERE id = ? AND ref_id = id  AND owner_uid = ?");
+		$sth->execute([$id, $_SESSION['uid']]);
+		if ($row = $sth->fetch()) {
+			$title = truncate_string(strip_tags($row['title']), 100, '...');
+			$article_link = $row['link'];
 		}
 
 		$yourls_url = $this->host->get($this, "Yourls_URL");

--- a/yourls/yourls.js
+++ b/yourls/yourls.js
@@ -13,7 +13,7 @@ function shareArticleToYourls(id) {
 					id: "YourlsShortLinkDlg"+ts,
 					title: __("Youlrs Shortened URL"),
 					style: "width: 200px",
-					content: '<p align=center>' + ti.shorturl + '<br/><a target="_blank" href="http://twitter.com/share?_=' + ts + '&text=' + encodeURIComponent(ti.title) + '&url=' + encodeURIComponent(ti.shorturl) + '"><img src="/plugins.local/yourls/tweetshare.png"/></a><br/><a target="_blank" href="http://www.facebook.com/sharer.php?u=' + encodeURIComponent(ti.shorturl) + '"><img src="/plugins.local/yourls/fbshare.png" border=0/></a></p>',
+					content: '<p align=center>' + ti.shorturl + '<br/><a target="_blank" href="https://twitter.com/share?_=' + ts + '&text=' + encodeURIComponent(ti.title) + '&url=' + encodeURIComponent(ti.shorturl) + '"><img src="/plugins.local/yourls/tweetshare.png"/></a><br/><a target="_blank" href="https://www.facebook.com/sharer.php?u=' + encodeURIComponent(ti.shorturl) + '"><img src="/plugins.local/yourls/fbshare.png" border=0/></a></p>',
 					});
 				dialog.show();
 			} });

--- a/yourls/yourls.js
+++ b/yourls/yourls.js
@@ -1,23 +1,19 @@
-	function shareArticleToYourls(id) {
+function shareArticleToYourls(id) {
 	try {
-		var query = "?op=pluginhandler&plugin=yourls&method=getInfo&id=" + param_escape(id);
-
+		var query = "?op=pluginhandler&plugin=yourls&method=getInfo&id=" + encodeURIComponent(id);
 		var d = new Date();
-	        var ts = d.getTime();
-
+	    var ts = d.getTime();
 
 		new Ajax.Request("backend.php",	{
 			parameters: query,
 			onSuccess: function(transport) {
 				var ti = JSON.parse(transport.responseText);
-				var share_url_query = "?signature=" + ti.yourlsapi + "&action=shorturl&format=simple&url=" + param_escape(ti.link) + "&title=" + param_escape(ti.title);
+				var share_url_query = "?signature=" + ti.yourlsapi + "&action=shorturl&format=simple&url=" + encodeURIComponent(ti.link) + "&title=" + encodeURIComponent(ti.title);
 				dialog = new dijit.Dialog({
 					id: "YourlsShortLinkDlg"+ts,
 					title: __("Youlrs Shortened URL"),
 					style: "width: 200px",
-					//content: "<iframe src='"+ti.yourlsurl + "/yourls-api.php" + share_url_query+"' frameborder='0' allowtransparency='true' scrolling='no' height='40px' width='190px'></iframe>",
-					content: '<p align=center>' + ti.shorturl + '<br/><a target="_blank" href="http://twitter.com/share?_=' + ts + '&text=' + param_escape(ti.title) +
-                                        '&url=' + param_escape(ti.shorturl) + '"><img src="/plugins/yourls/tweetshare.png"/></a><br/><a target="_blank" href="http://www.facebook.com/sharer.php?u=' + param_escape(ti.shorturl) + '"><img src="/plugins/yourls/fbshare.png" border=0/></a><br/><a target="_blank" href="http://hootsuite.com/hootlet/load?address='+param_escape(ti.shorturl)+'&title='+param_escape(ti.title)+'"><img src="http://s1.static.hootsuite.com/33797-5102/images/static/socialshare/share-btn-med.png"/></a></p>',
+					content: '<p align=center>' + ti.shorturl + '<br/><a target="_blank" href="http://twitter.com/share?_=' + ts + '&text=' + encodeURIComponent(ti.title) + '&url=' + encodeURIComponent(ti.shorturl) + '"><img src="/plugins.local/yourls/tweetshare.png"/></a><br/><a target="_blank" href="http://www.facebook.com/sharer.php?u=' + encodeURIComponent(ti.shorturl) + '"><img src="/plugins.local/yourls/fbshare.png" border=0/></a></p>',
 					});
 				dialog.show();
 			} });
@@ -25,5 +21,4 @@
 	} catch (e) {
 		exception_error("yourlsArticle", e);
 	}
-	}
-
+}


### PR DESCRIPTION
Bugfix
-  update js to ttrss v18.12 (fca78f7)  
-  update from legacy db_connect
-  fixes #4 (installation instruction to correct directory + hard-coded paths in js)  

Enhancement
-  add keyboard shortcut "s+y"
-  add material link icon to pref tab
-  make facebook and twitter shares https
-  switch to semantic versioning
-  tidy code